### PR TITLE
Use WKB instead of native encoding

### DIFF
--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -89,11 +89,14 @@ pub struct OpfsFile {
 unsafe impl std::marker::Send for OpfsFile {}
 
 impl OpfsFile {
-    pub fn new(file: web_sys::FileSystemSyncAccessHandle) -> Self {
-        Self {
+    pub fn new(file: web_sys::FileSystemSyncAccessHandle) -> Result<Self, JsValue> {
+        // currently, the same name of file is repeatedly used, so it needs to be truncated first.
+        file.truncate_with_u32(0)?;
+
+        Ok(Self {
             file,
             offset: FileSystemReadWriteOptions::new(),
-        }
+        })
     }
 }
 


### PR DESCRIPTION
Currently, few implementation can read native encoding, which is a spec of GeoParquet v1.1. So, while it's efficient to use native encoding, it seems it's safe to use WKB for now.