### PR TITLE
Handle .prj

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "geoparquet",
  "itertools",
  "parquet",
+ "serde_json",
  "shapefile",
  "wasm-bindgen",
  "web-sys",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -50,6 +50,7 @@ zip = { version = "4.5.0", default-features = false, features = ["deflate"] }
 
 # for .chunk()
 itertools = "0.14.0"
+serde_json = "1.0.143"
 
 [patch.crates-io]
 dbase = { git = "https://github.com/tmontaigu/dbase-rs" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -31,6 +31,10 @@ shapefile = { git = "https://github.com/tmontaigu/shapefile-rs", version = "0.7.
 dbase = { git = "https://github.com/tmontaigu/dbase-rs", version = "0.6.0", features = ["encoding_rs"] }
 encoding_rs = "0.8.35"
 
+# TODO: CRS conversion
+# proj4rs = { version = "0.1.8", default-features = false }
+# proj4wkt = { version = "0.1.0", default-features = false }
+
 # WASM
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [

--- a/rust/src/crs/epsg4612.json
+++ b/rust/src/crs/epsg4612.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+  "type": "GeographicCRS",
+  "name": "JGD2000",
+  "datum": {
+    "type": "GeodeticReferenceFrame",
+    "name": "Japanese Geodetic Datum 2000",
+    "ellipsoid": {
+      "name": "GRS 1980",
+      "semi_major_axis": 6378137,
+      "inverse_flattening": 298.257222101
+    }
+  },
+  "coordinate_system": {
+    "subtype": "ellipsoidal",
+    "axis": [
+      {
+        "name": "Geodetic latitude",
+        "abbreviation": "Lat",
+        "direction": "north",
+        "unit": "degree"
+      },
+      {
+        "name": "Geodetic longitude",
+        "abbreviation": "Lon",
+        "direction": "east",
+        "unit": "degree"
+      }
+    ]
+  },
+  "scope": "Horizontal component of 3D system.",
+  "area": "Japan - onshore and offshore.",
+  "bbox": {
+    "south_latitude": 17.09,
+    "west_longitude": 122.38,
+    "north_latitude": 46.05,
+    "east_longitude": 157.65
+  },
+  "id": {
+    "authority": "EPSG",
+    "code": 4612
+  }
+}

--- a/rust/src/crs/epsg6668.json
+++ b/rust/src/crs/epsg6668.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+  "type": "GeographicCRS",
+  "name": "JGD2011",
+  "datum": {
+    "type": "GeodeticReferenceFrame",
+    "name": "Japanese Geodetic Datum 2011",
+    "ellipsoid": {
+      "name": "GRS 1980",
+      "semi_major_axis": 6378137,
+      "inverse_flattening": 298.257222101
+    }
+  },
+  "coordinate_system": {
+    "subtype": "ellipsoidal",
+    "axis": [
+      {
+        "name": "Geodetic latitude",
+        "abbreviation": "Lat",
+        "direction": "north",
+        "unit": "degree"
+      },
+      {
+        "name": "Geodetic longitude",
+        "abbreviation": "Lon",
+        "direction": "east",
+        "unit": "degree"
+      }
+    ]
+  },
+  "scope": "Horizontal component of 3D system.",
+  "area": "Japan - onshore and offshore.",
+  "bbox": {
+    "south_latitude": 17.09,
+    "west_longitude": 122.38,
+    "north_latitude": 46.05,
+    "east_longitude": 157.65
+  },
+  "id": {
+    "authority": "EPSG",
+    "code": 6668
+  }
+}

--- a/rust/src/crs/mod.rs
+++ b/rust/src/crs/mod.rs
@@ -1,0 +1,20 @@
+use std::str::FromStr;
+
+use wasm_bindgen::JsValue;
+
+const EPSG4612: &str = include_str!("epsg4612.json");
+const EPSG6668: &str = include_str!("epsg6668.json");
+
+pub fn wild_guess_from_esri_wkt_to_projjson(wkt: &str) -> Result<serde_json::Value, JsValue> {
+    if wkt.contains("GCS_JGD_2011") {
+        let parsed = serde_json::Value::from_str(EPSG6668).unwrap();
+        return Ok(parsed);
+    }
+
+    if wkt.contains("GCS_JGD_2000") {
+        let parsed = serde_json::Value::from_str(EPSG4612).unwrap();
+        return Ok(parsed);
+    }
+
+    Err(format!("Failed to identify CRS from ESRI WKT in the .prj file: {wkt}").into())
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,8 +9,12 @@ use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use web_sys::FileReaderSync;
 
-use crate::io::{OpfsFile, UserLocalFile};
+use crate::{
+    crs::wild_guess_from_esri_wkt_to_projjson,
+    io::{OpfsFile, UserLocalFile},
+};
 
+mod crs;
 mod io;
 mod zip;
 
@@ -69,7 +73,8 @@ pub fn list_files(
     //
     // cf. https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems#Backward_compatibility
     let wkt = zip.read_prj()?;
-    let crs = geoarrow_schema::Crs::from_wkt2_2019(wkt);
+    let projjson = wild_guess_from_esri_wkt_to_projjson(&wkt)?;
+    let crs = geoarrow_schema::Crs::from_projjson(projjson);
 
     web_sys::console::log_1(&format!("CRS: {crs:?}").into());
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,7 +25,6 @@ pub struct IntermediateFiles {
     shp: web_sys::FileSystemSyncAccessHandle,
     dbf: web_sys::FileSystemSyncAccessHandle,
     shx: web_sys::FileSystemSyncAccessHandle,
-    // prj: web_sys::FileSystemSyncAccessHandle, // TODO
 }
 
 #[wasm_bindgen]
@@ -62,8 +61,17 @@ pub fn list_files(
 
     let shapefile_reader =
         ShapeReader::with_shx(shp_file_opfs, shx_file_opfs).map_err(|e| -> JsValue {
-            format!("Got an error on Reading .shp and .shx files: {e:?}").into()
+            format!("Got an error on reading .shp and .shx files: {e:?}").into()
         })?;
+
+    // Note: .prj file is writtien in WKT1, not WKT2. But, it seems it's mostly
+    // backward-compatible. I'm not fully sure, but this should work...
+    //
+    // cf. https://en.wikipedia.org/wiki/Well-known_text_representation_of_coordinate_reference_systems#Backward_compatibility
+    let wkt = zip.read_prj()?;
+    let crs = geoarrow_schema::Crs::from_wkt2_2019(wkt);
+
+    web_sys::console::log_1(&format!("CRS: {crs:?}").into());
 
     let dbase_reader = shapefile::dbase::Reader::new_with_encoding(
         dbf_file_opfs,
@@ -72,23 +80,18 @@ pub fn list_files(
     .map_err(|e| -> JsValue { format!("Got an error on Reading a .dbf file: {e:?}").into() })?;
 
     let dbf_fields = dbase_reader.fields().to_vec();
-    let fields_info = infer_schema(&dbf_fields);
+    let fields_info = construct_schema(&dbf_fields, crs);
     let schema_ref = fields_info.schema_ref.clone();
 
     for f in &fields_info.non_geo_fields {
         web_sys::console::log_1(&format!("field: {f:?}").into());
     }
-    web_sys::console::log_1(&format!("geometry: {:?}", &fields_info.geo_arrow_type).into());
+    web_sys::console::log_1(&format!("geometry: {:?}", &fields_info.geoarrow_type).into());
 
     let mut reader = Reader::new(shapefile_reader, dbase_reader);
 
     let options = GeoParquetWriterOptionsBuilder::default()
-        // .set_crs_transform(Box::new(todo!())) // TODO
         .set_encoding(geoparquet::writer::GeoParquetWriterEncoding::WKB)
-        // .set_column_encoding(
-        //     "geometry".to_string(),
-        //     geoparquet::writer::GeoParquetWriterEncoding::GeoArrow,
-        // )
         .set_generate_covering(true)
         .build();
     let mut gpq_encoder =
@@ -171,7 +174,7 @@ pub fn list_files(
 struct FieldsWithGeo {
     schema_ref: arrow_schema::SchemaRef,
     non_geo_fields: Vec<Arc<arrow_schema::Field>>,
-    geo_arrow_type: geoarrow_schema::GeoArrowType,
+    geoarrow_type: geoarrow_schema::GeoArrowType,
 }
 
 #[derive(Debug)]
@@ -335,7 +338,7 @@ impl ArrayBuilderWithGeo {
 // This function is derived from geoarrow-rs's old code, which is licensed under MIT/Apache
 //
 // https://github.com/geoarrow/geoarrow-rs/blob/06e1d615134b249eb5fee39020673c8659978d18/rust/geoarrow-old/src/io/shapefile/reader.rs#L385-L411
-fn infer_schema(fields: &[FieldInfo]) -> FieldsWithGeo {
+fn construct_schema(fields: &[FieldInfo], crs: geoarrow_schema::Crs) -> FieldsWithGeo {
     let mut non_geo_fields = Vec::with_capacity(fields.len());
 
     for field in fields {
@@ -370,15 +373,17 @@ fn infer_schema(fields: &[FieldInfo]) -> FieldsWithGeo {
         non_geo_fields.push(Arc::new(field));
     }
 
-    let geo_arrow_type = GeoArrowType::Wkb(WkbType::new(Default::default()));
+    let geoarrow_metadata = geoarrow_schema::Metadata::new(crs, None);
+    let geoarrow_type = GeoArrowType::Wkb(WkbType::new(geoarrow_metadata.into()));
+    let geo_field = geoarrow_type.to_field("geometry", true);
 
     let mut fields = non_geo_fields.clone();
-    fields.push(Arc::new(geo_arrow_type.to_field("geometry", true)));
+    fields.push(Arc::new(geo_field));
     let schema_ref = Arc::new(arrow_schema::Schema::new(fields));
 
     FieldsWithGeo {
         schema_ref,
         non_geo_fields,
-        geo_arrow_type,
+        geoarrow_type,
     }
 }

--- a/rust/src/zip.rs
+++ b/rust/src/zip.rs
@@ -1,4 +1,4 @@
-use std::io::Seek as _;
+use std::io::{Read, Seek as _};
 
 use wasm_bindgen::JsValue;
 use zip::ZipArchive;
@@ -10,7 +10,7 @@ pub struct ZipReader {
     shp_filename: String,
     dbf_filename: String,
     shx_filename: String,
-    // prj: String // TODO
+    prj_filename: String,
 }
 
 impl ZipReader {
@@ -20,6 +20,7 @@ impl ZipReader {
         let shp_filename = find_specific_ext(&filenames, ".shp")?;
         let dbf_filename = find_specific_ext(&filenames, ".dbf")?;
         let shx_filename = find_specific_ext(&filenames, ".shx")?;
+        let prj_filename = find_specific_ext(&filenames, ".prj")?;
 
         drop(filenames);
 
@@ -28,6 +29,7 @@ impl ZipReader {
             shp_filename,
             dbf_filename,
             shx_filename,
+            prj_filename,
         })
     }
 
@@ -54,6 +56,16 @@ impl ZipReader {
 
     pub fn copy_shx_to(&mut self, dst: &mut OpfsFile) -> Result<(), JsValue> {
         self.copy_to(dst, &self.shx_filename.clone())
+    }
+
+    pub fn read_prj(&mut self) -> Result<String, JsValue> {
+        let mut reader = self.zip.by_name(&self.prj_filename).unwrap();
+        let mut wkt = String::new();
+        reader.read_to_string(&mut wkt).map_err(|e| -> JsValue {
+            format!("Got an error while reading .prj file: {e:?}").into()
+        })?;
+
+        Ok(wkt)
     }
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,7 +7,9 @@ onmessage = async (event) => {
 
   const opfsRoot = await navigator.storage.getDirectory();
 
-  const outputFileHandle = await opfsRoot.getFileHandle("tmp.parquet", { create: true });
+  const outputFileHandle = await opfsRoot.getFileHandle("tmp.parquet", {
+    create: true,
+  });
   const outputFile = await outputFileHandle.createSyncAccessHandle();
 
   // TODO: use random file names
@@ -26,10 +28,10 @@ onmessage = async (event) => {
     postMessage({ ok: false, error: msg });
   } finally {
     // Ensure handles are closed even on failure
-    try { outputFile.close(); } catch {}
-    try { shp.close(); } catch {}
-    try { dbf.close(); } catch {}
-    try { shx.close(); } catch {}
+    outputFile.close();
+    shp.close();
+    dbf.close();
+    shx.close();
   }
 };
 


### PR DESCRIPTION
Close #9 

Some findings:

- While GeoArrow's spec allows CRS specification in other formats than PROJJSON, GeoParquet allows PROJJSON only. Probably for this reason, the geoparquet crate silently ignores other CRS format....
- There's no pure-Rust implementation for converting ESRI WKT to PROJJSON. Instead of implementing it seriously, I chose to support only JDG2000 and JDG2011.