### PR TITLE
Use more meaningful filename than "tmp.parquet"

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,11 +5,17 @@ export type WorkerRequest = {
 	target_shp?: string;
 };
 
+export type ResultFile = {
+	handle: FileSystemFileHandle;
+	filename: string;
+};
+
 export type WorkerResponse = {
 	ready?: boolean;
 	error?: string;
-	handle?: FileSystemFileHandle;
 	// When multiple .shp files are detected in the archive, the worker returns
 	// the list so the main thread can prompt the user to choose one.
-	shp_files?: string[];
+	shp_file_candidates?: string[];
+	// Result file (e.g. GeoParquet)
+	output: ResultFile;
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -52,21 +52,21 @@
 				return;
 			}
 
-			if (data.shp_files && data.shp_files.length > 1) {
-				shpOptions = data.shp_files;
+			if (data.shp_file_candidates && data.shp_file_candidates.length > 1) {
+				shpOptions = data.shp_file_candidates;
 				shpDialogOpen = true;
 				busy = false; // let user choose
 				return;
 			}
 
-			if (!data.handle) return;
+			if (!data.output) return;
 
-			const file = await data.handle.getFile();
+			const file = await data.output.handle.getFile();
 			const url = URL.createObjectURL(file);
 
 			const a = document.createElement('a');
 			a.href = url;
-			a.download = file.name || 'tmp.parquet';
+			a.download = data.output.filename;
 			document.body.appendChild(a);
 			a.click();
 


### PR DESCRIPTION
- The filename on OPFS is still `tmp.parquet`
- the downloaded file is properly named after the original shapefile.