### PR TITLE
Handle coordinates in radians, not in degrees

### DIFF
--- a/rust/src/transform_coord.rs
+++ b/rust/src/transform_coord.rs
@@ -77,18 +77,28 @@ impl CoordTransformer {
         &self,
         point: &shapefile::Point,
     ) -> Result<geojson::Position, Ksj2GpError> {
-        let mut pt = (point.x, point.y);
+        // Note: proj4rs requires the longitude and latitude in radian, not in degree.
+        // So, we must convert it to radians and then convert back to degree...
+        let mut pt = (point.x.to_radians(), point.y.to_radians());
         proj4rs::transform::transform(&self.from, &self.to, &mut pt)?;
-        Ok(vec![pt.0, pt.1])
+        Ok(vec![pt.0.to_degrees(), pt.1.to_degrees()])
     }
 
     fn transform_single_point_z(
         &self,
         point: &shapefile::PointZ,
     ) -> Result<geojson::Position, Ksj2GpError> {
-        let mut pt = (point.x, point.y, point.z);
+        let mut pt = (
+            point.x.to_radians(),
+            point.y.to_radians(),
+            point.z.to_radians(),
+        );
         proj4rs::transform::transform(&self.from, &self.to, &mut pt)?;
-        Ok(vec![pt.0, pt.1, pt.2])
+        Ok(vec![
+            pt.0.to_degrees(),
+            pt.1.to_degrees(),
+            pt.2.to_degrees(),
+        ])
     }
 
     fn transform_points(

--- a/rust/src/writer/geojson_writer.rs
+++ b/rust/src/writer/geojson_writer.rs
@@ -18,12 +18,12 @@ pub(crate) fn write_geojson<T: Read + Seek, D: Read + Seek>(
     web_sys::console::log_1(&"writing geojson".into());
 
     // TODO: Use LazyCell
-    let proj_from = Proj::from_proj_string(concat!(
+    let proj_to = Proj::from_proj_string(concat!(
         "+proj=longlat +ellps=WGS84",
         " +datum=WGS84 +no_defs"
     ))?;
-    let proj_str_to = proj4wkt::wkt_to_projstring(wkt).map_err(|e| e.to_string())?;
-    let proj_to = Proj::from_proj_string(&proj_str_to)?;
+    let proj_str_from = proj4wkt::wkt_to_projstring(wkt).map_err(|e| e.to_string())?;
+    let proj_from = Proj::from_proj_string(&proj_str_from)?;
     let transformer = CoordTransformer::new(proj_from, proj_to);
 
     // Since shapefile::Record is a HashMap, the iterator of it doesn't maintain


### PR DESCRIPTION
Fix #41 

In #40, I made 2 fatal mistakes...

1. While proj4rs requires latitude and longitude in radian, not in degree, I naively chose degree values
2. I simply swap the from and to of the transformation.

This pull request fixes it.