### PR TITLE
Remove proj4rs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -354,16 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "console_log"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
-dependencies = [
- "log",
- "web-sys",
-]
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,8 +785,6 @@ dependencies = [
  "geoparquet",
  "itertools",
  "parquet",
- "proj4rs",
- "proj4wkt",
  "serde_json",
  "shapefile",
  "zip",
@@ -931,15 +919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1120,33 +1099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proj4rs"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3c4a66ce46a8b4514d0dce1e7a39b3d2b3a6125f7968093020f96a8a5ad09b"
-dependencies = [
- "console_log",
- "js-sys",
- "thiserror 2.0.16",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "proj4wkt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098a0cc36b6bfd623f7a34354be6f6bd7ac3621e96ccaf2cf08720f28868203d"
-dependencies = [
- "console_log",
- "js-sys",
- "nom",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,9 +30,6 @@ shapefile = { git = "https://github.com/tmontaigu/shapefile-rs", version = "0.7.
 # since WASM build is broken with the crates.io version, use Git version: https://github.com/tmontaigu/dbase-rs/issues/100
 dbase = { version = "0.6.1", features = ["encoding_rs"] }
 
-proj4rs = { version = "0.1.8", default-features = false }
-proj4wkt = { version = "0.1.0", default-features = false }
-
 # Read Zip file
 zip = { workspace = true }
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -57,12 +57,6 @@ impl From<parquet::errors::ParquetError> for Ksj2GpError {
     }
 }
 
-impl From<proj4rs::errors::Error> for Ksj2GpError {
-    fn from(value: proj4rs::errors::Error) -> Self {
-        Self(format!("proj4rs error: {value:?}").into())
-    }
-}
-
 impl From<&str> for Ksj2GpError {
     fn from(value: &str) -> Self {
         Self(value.into())

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -65,7 +65,7 @@ pub fn convert_shp_inner<RW: Read + Seek + Write, R: Read + Seek, W: Write + Sen
 
     match output_format {
         "GeoParquet" => write_geoparquet(&mut reader, &mut out, &dbf_fields, &wkt),
-        "GeoJson" => write_geojson(&mut reader, &mut out, &dbf_fields, &wkt),
+        "GeoJson" => write_geojson(&mut reader, &mut out, &dbf_fields),
         _ => Err(format!("Unsupported format: {output_format}").into()),
     }
 }

--- a/rust/src/transform_coord.rs
+++ b/rust/src/transform_coord.rs
@@ -1,16 +1,12 @@
-use proj4rs::Proj;
 use shapefile::Shape;
 
 use crate::error::Ksj2GpError;
 
-pub struct CoordTransformer {
-    from: Proj,
-    to: Proj,
-}
+pub struct CoordTransformer {}
 
 impl CoordTransformer {
-    pub fn new(from: Proj, to: Proj) -> Self {
-        Self { from, to }
+    pub fn new() -> Self {
+        Self {}
     }
     pub fn transform_to_geojson(&self, shape: &Shape) -> Result<geojson::Value, Ksj2GpError> {
         match shape {
@@ -77,28 +73,18 @@ impl CoordTransformer {
         &self,
         point: &shapefile::Point,
     ) -> Result<geojson::Position, Ksj2GpError> {
-        // Note: proj4rs requires the longitude and latitude in radian, not in degree.
-        // So, we must convert it to radians and then convert back to degree...
-        let mut pt = (point.x.to_radians(), point.y.to_radians());
-        proj4rs::transform::transform(&self.from, &self.to, &mut pt)?;
-        Ok(vec![pt.0.to_degrees(), pt.1.to_degrees()])
+        // TODO: add PatchJDG transformation here
+
+        Ok(vec![point.x, point.y])
     }
 
     fn transform_single_point_z(
         &self,
         point: &shapefile::PointZ,
     ) -> Result<geojson::Position, Ksj2GpError> {
-        let mut pt = (
-            point.x.to_radians(),
-            point.y.to_radians(),
-            point.z.to_radians(),
-        );
-        proj4rs::transform::transform(&self.from, &self.to, &mut pt)?;
-        Ok(vec![
-            pt.0.to_degrees(),
-            pt.1.to_degrees(),
-            pt.2.to_degrees(),
-        ])
+        // TODO: add PatchJDG transformation here
+
+        Ok(vec![point.x, point.y, point.z])
     }
 
     fn transform_points(

--- a/rust/src/writer/geojson_writer.rs
+++ b/rust/src/writer/geojson_writer.rs
@@ -1,7 +1,6 @@
 use std::io::{Read, Seek, Write};
 
 use geojson::JsonObject;
-use proj4rs::Proj;
 
 use crate::{
     error::Ksj2GpError, transform_coord::CoordTransformer, writer::get_fields_except_geometry,
@@ -11,18 +10,8 @@ pub(crate) fn write_geojson<T: Read + Seek, D: Read + Seek, W: Write + Send>(
     reader: &mut shapefile::Reader<T, D>,
     writer: &mut W,
     dbf_fields: &[dbase::FieldInfo],
-    wkt: &str,
 ) -> Result<(), Ksj2GpError> {
-    // TODO: Use LazyCell
-    let proj_to = Proj::from_proj_string(concat!(
-        "+proj=longlat +ellps=WGS84",
-        " +datum=WGS84 +no_defs"
-    ))?;
-
-    let proj_str_from = proj4wkt::wkt_to_projstring(wkt).map_err(|e| e.to_string())?;
-    let proj_from = Proj::from_proj_string(&proj_str_from)?;
-
-    let transformer = CoordTransformer::new(proj_from, proj_to);
+    let transformer = CoordTransformer::new();
 
     // Since shapefile::Record is a HashMap, the iterator of it doesn't maintain
     // the order. So, this column names vector is needed to ensure the consistent

--- a/rust/src/writer/geoparquet_writer.rs
+++ b/rust/src/writer/geoparquet_writer.rs
@@ -16,9 +16,13 @@ pub(crate) fn write_geoparquet<T: Read + Seek, D: Read + Seek, W: Write + Send>(
     reader: &mut shapefile::Reader<T, D>,
     writer: &mut W,
     dbf_fields: &[dbase::FieldInfo],
-    wkt: &str,
+    wkt: &Option<String>,
 ) -> Result<(), Ksj2GpError> {
-    let projjson = wild_guess_from_esri_wkt_to_projjson(wkt)?;
+    let projjson = match wkt {
+        Some(wkt) => wild_guess_from_esri_wkt_to_projjson(wkt)?,
+        // TODO: if .prj is not found, guess from other information
+        None => return Err(format!(".prj not found").into()),
+    };
     let crs = geoarrow_schema::Crs::from_projjson(projjson);
 
     let fields_info = construct_schema(dbf_fields, crs);

--- a/rust/src/zip_reader.rs
+++ b/rust/src/zip_reader.rs
@@ -91,12 +91,16 @@ impl<R: Read + Seek> ZippedShapefileReader<R> {
         self.copy_to(dst, &self.shx_filename.clone())
     }
 
-    pub fn read_prj(&mut self) -> Result<String, Ksj2GpError> {
-        let mut reader = self.zip.by_name(&self.prj_filename).unwrap();
+    pub fn read_prj(&mut self) -> Result<Option<String>, Ksj2GpError> {
+        let mut reader = match self.zip.by_name(&self.prj_filename) {
+            Ok(reader) => reader,
+            Err(zip::result::ZipError::FileNotFound) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
         let mut wkt = String::new();
         reader.read_to_string(&mut wkt)?;
 
-        Ok(wkt)
+        Ok(Some(wkt))
     }
 
     // cf. https://github.com/EsriJapan/shapefile_info


### PR DESCRIPTION
Currently, proj4rs is used for transforming the coordinates from JGD2000/JGD2011 to WGS84. However, it actually does nothing.

If ksj2gp supports other CRS, it still makes sense, but currently it's effectively not used. In future, I want to implement https://github.com/yutannihilation/ksj2gp/issues/68 for transformation, so leave the transform interface as it is, but just removes proj4rs.