### PR TITLE
fix(gpkg): Update rusqlite-gpkg to fix various bugs

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite-gpkg"
-version = "0.0.7"
+version = "0.0.8-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f554a5e27525523ea2cdb574641e0fec1672d6f8a03559ba1577a744673f01"
+checksum = "d80f07815fe5b377035eed00b99e18789761980546209b468512f0f7f17f5e8c"
 dependencies = [
  "geo-traits",
  "rusqlite",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,7 +37,8 @@ itertools = "0.14.0"
 encoding_rs = "0.8.35"
 regex = { version = "1.11.3", default-features = false, features = ["std"] }
 proj4rs = { version = "0.1.9", default-features = false }
-rusqlite-gpkg = "0.0.7"
+rusqlite-gpkg = "0.0.8-beta.2"
+# rusqlite-gpkg = { version = "0.0.8", path = "../../rusqlite-gpkg" }
 geo-types = "0.7.18"
 serde_json = "1.0.149"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -48,7 +48,7 @@ pub fn find_meta_xml<R: Read + Seek>(reader: R) -> Result<Option<String>, Ksj2Gp
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn convert_shp_inner<RW: Read + Seek + Write, R: Read + Seek, W: Write + Send + 'static>(
+pub fn convert_shp_inner<RW: Read + Seek + Write, R: Read + Seek, W: Write + Seek + Send + 'static>(
     zip: R,
     target_shp: &str,
     meta_xml_filename: Option<String>,

--- a/rust/src/writer/gpkg_writer.rs
+++ b/rust/src/writer/gpkg_writer.rs
@@ -11,7 +11,7 @@ use crate::{
     writer::get_fields_except_geometry,
 };
 
-pub(crate) fn write_gpkg<T: Read + Seek, D: Read + Seek, W: Write + Send + 'static>(
+pub(crate) fn write_gpkg<T: Read + Seek, D: Read + Seek, W: Write + Seek + Send + 'static>(
     reader: &mut shapefile::Reader<T, D>,
     writer: W,
     dbf_fields: &[dbase::FieldInfo],


### PR DESCRIPTION
Gpkg の出力が壊れていたのを修正する

- OPFS を使えていなかった（ https://github.com/yutannihilation/rusqlite-gpkg/pull/39 ）
- OPFS ファイルを使いまわすので、2回目以降データがおかしくなる（ https://github.com/yutannihilation/rusqlite-gpkg/pull/40 、 https://github.com/yutannihilation/rusqlite-gpkg/pull/41 ）