### PR TITLE
fix: LDID in .dbf file is the 30th byte, not 29th

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -39,7 +39,7 @@ https://github.com/EsriJapan/shapefile_info
 
 ksj2gp では、これに従ってまずは以下で文字コードを決められるか試します。
 
-- `.dbf` ファイルの 29 バイト目が `13` の場合は Shift_JIS
+- `.dbf` ファイルの 30 バイト目が `13` の場合は Shift_JIS
 - `.cpg` ファイルが存在する場合
   - 中身が `CP932` なら Shift_JIS
   - 中身が `UTF-8` なら UTF-8

--- a/rust/src/zip_reader.rs
+++ b/rust/src/zip_reader.rs
@@ -151,9 +151,9 @@ impl<R: Read + Seek> ZippedShapefileReader<R> {
                 let mut cpg = String::new();
                 reader.read_to_string(&mut cpg)?;
 
-                return DynEncoding::from_name(&cpg)
-                    .map(Some)
-                    .ok_or_else(|| format!("Unknown encoding is found in .cpg file: {cpg}").into());
+                return DynEncoding::from_name(&cpg).map(Some).ok_or_else(|| {
+                    format!("Unknown encoding is found in .cpg file: {cpg}").into()
+                });
             }
             Err(zip::result::ZipError::FileNotFound) => {} // If ZIP file doesn't contain .cpg file, use other heuristics...
             Err(e) => return Err(e.into()),
@@ -170,13 +170,13 @@ impl<R: Read + Seek> ZippedShapefileReader<R> {
             return Ok(Some(EncodingRs::from(dbase::encoding_rs::UTF_8).into()));
         }
 
-        // If LDID (29th byte of dBASE file) is not set (i.e. 0), dbase would
+        // If LDID (30th byte of dBASE file) is not set (i.e. 0), dbase would
         // treat the file as UTF-8, but such files are most likely Shift_JIS
         // in Japanese data. If LDID is set, leave the detection to dbase.
         let mut dbf_reader = self.zip.by_name(&self.dbf_filename).unwrap();
-        let mut buf = vec![0u8; 29];
+        let mut buf = vec![0u8; 30];
         dbf_reader.read_exact(&mut buf)?;
-        if buf[28] == 0 {
+        if buf[29] == 0 {
             return Ok(Some(EncodingRs::from(dbase::encoding_rs::SHIFT_JIS).into()));
         }
 


### PR DESCRIPTION
<https://github.com/EsriJapan/shapefile_info> に書かれている「29バイト目」は、30バイト目という意味だった...